### PR TITLE
Make request import from urllib explicit

### DIFF
--- a/harbinger/cli/main.py
+++ b/harbinger/cli/main.py
@@ -61,7 +61,7 @@ def main():
         try:
             username = os.environ[username_envvar]
         except KeyError:
-            print('Environment variable {} not defined.')
+            print(f'Environment variable {username_envvar} not defined.')
             print('Store the Github password in that variable or run with '
                   '`-p` to prompt for the password interactively.'.format(
                       username_envvar))

--- a/harbinger/scanner.py
+++ b/harbinger/scanner.py
@@ -1,5 +1,6 @@
 import os
 import urllib
+from urllib import request
 import configparser
 import yaml
 import github3
@@ -31,8 +32,8 @@ class Scanner():
         self.acc = self.gh.user(org)
 
     def getjson(self, url):
-        request = urllib.request.Request(url)
-        result = urllib.request.urlopen(request)
+        req = request.Request(url)
+        result = request.urlopen(req)
         payload = result.read()
         jdata = json.loads(payload.decode())
         return jdata
@@ -62,9 +63,9 @@ class Scanner():
             #       file blob.
             base_url = 'https://raw.githubusercontent.com/'
             url = f'{base_url}{self.org}/{repo}/master/{self.cfg_file}'
-            request = urllib.request.Request(url)
+            req = request.Request(url)
             try:
-                result = urllib.request.urlopen(request)
+                result = request.urlopen(req)
             except urllib.error.HTTPError as e:
                 continue
             print(f'{repo}: Found config')

--- a/setup.py
+++ b/setup.py
@@ -2,7 +2,7 @@ from setuptools import setup, find_packages
 
 setup(
     name='harbinger',
-    version='0.0.1',
+    version='0.0.2',
     packages=find_packages(),
     entry_points={
         'console_scripts': [


### PR DESCRIPTION
This removes the dependence upon the somewhat confusing behavior that makes `urllib.request` only after `github3.py` is imported.